### PR TITLE
Fixes for two of the fuzzing issues

### DIFF
--- a/aacparser.go
+++ b/aacparser.go
@@ -838,7 +838,7 @@ func (adts *ADTS) adts_fixed_header() error {
 		adts.Profile += uint8(1)                                // profile object
 		adts.sfi, _ = adts.reader.ReadBitsAsUInt8(4)            // sampling_frequency_index
 		if adts.sfi > 12 {
-			return fmt.Errorf("Scale Factor Index (%d) out of acceptable range (0-12)", adts.sfi)
+			return fmt.Errorf("Sampling Frequency Index (%d) out of acceptable range (0-12)", adts.sfi)
 		}
 
 		adts.SamplingFrequency = SamplingFrequency[adts.sfi]          // sampling frequency
@@ -890,7 +890,7 @@ func (adts *ADTS) adts_header_error_check() {
 	data := &adts_header_error_check{}
 
 	if !adts.protection_absent {
-		data.Raw_data_block_position = make([]uint16, adts.num_raw_data_blocks)
+		data.Raw_data_block_position = make([]uint16, adts.num_raw_data_blocks+1)
 		for i := uint8(1); i <= adts.num_raw_data_blocks; i++ {
 			data.Raw_data_block_position[i], _ = adts.reader.ReadBitsAsUInt16(16) // raw_data_block_position
 		}

--- a/aacparser_test.go
+++ b/aacparser_test.go
@@ -264,3 +264,26 @@ func TestEightShortSequence(t *testing.T) {
 		}
 	}
 }
+
+// Fuzz testing courtesy of gy741
+func TestWindowGroupingFuzz(t *testing.T) {
+
+	var crashers = []string{
+		"\xff\xf10\x850",
+	}
+
+	for _, f := range crashers {
+		ParseADTS([]byte(f))
+	}
+}
+
+func TestADTSHeaderFuzz(t *testing.T) {
+
+	var crashers = []string{
+		"\xff\xf00000\x010",
+	}
+
+	for _, f := range crashers {
+		ParseADTS([]byte(f))
+	}
+}

--- a/aacwindowgrouping.go
+++ b/aacwindowgrouping.go
@@ -22,8 +22,8 @@ package gaad
 // maximum index into the swb_offset tables each bitrate
 // is allowed to use
 var num_swb_long_windows = [][]uint8{
-	{40, 40, 45, 49, 49, 49, 46, 46, 42, 42, 42, 40}, // 960
-	{41, 41, 47, 49, 49, 51, 47, 47, 43, 43, 43, 40}, // 1024
+	{40, 40, 46, 49, 49, 49, 46, 46, 42, 42, 42, 40, 40}, // 960
+	{41, 41, 47, 49, 49, 51, 47, 47, 43, 43, 43, 40, 40}, // 1024
 }
 
 // num_swb_short_window param from tables 4.130 through 1.141
@@ -121,7 +121,7 @@ var swb_offset_long_window = [][]uint16{
 	swb_offset_1024_32,                     // 32000
 	swb_offset_1024_24, swb_offset_1024_24, // 24000, 22050
 	swb_offset_1024_16, swb_offset_1024_16, swb_offset_1024_16, // 16000, 12000, 11025
-	swb_offset_1024_8, // 8000
+	swb_offset_1024_8, swb_offset_1024_8, // 8000
 }
 
 var swb_offset_short_window = [][]uint16{
@@ -130,7 +130,7 @@ var swb_offset_short_window = [][]uint16{
 	swb_offset_128_48, swb_offset_128_48, swb_offset_128_48, // 48000, 44100, 32000
 	swb_offset_128_24, swb_offset_128_24, // 24000, 22050
 	swb_offset_128_16, swb_offset_128_16, swb_offset_128_16, // 16000, 12000, 11025
-	swb_offset_128_8, // 8000
+	swb_offset_128_8, swb_offset_128_8, // 8000
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Notes

I'll preface this by saying I didn't reference the spec for these two issues. The first fix is that the Scale Factor Index table only goes to 11 in the look up table. This fix addresses issue #10 

The second fix just ensures that the Raw_data_block_position array is not accessed out of bound. This addresses issue #9 