### PR TITLE
travis: update to Go 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
 
 go:
-- 1.6.2
+- 1.13
 - tip


### PR DESCRIPTION
`.travis.yml` was still testing against Go 1.6.