### PR TITLE
Ignore extensions while not supported, fix misc

### DIFF
--- a/aacparser.go
+++ b/aacparser.go
@@ -2152,31 +2152,7 @@ func (adts *ADTS) sbr_channel_pair_element(ext_data *sbr_extension_data, bs_amp_
 			return e, fmt.Errorf("Too many bits left, check bitstream continuity")
 		}
 
-		// TODO: Uncomment this when extensions are supported.
-		// For now this is risky when the bitstream is goofed;
-		// Sometimes is tries to allocate the world.
-		// e.Bs_extension_id = make([]uint8, 0)
-		// e.Sbr_extension = make([]*sbr_extension, 0)
-		// for i := 0; num_bits_left > 7; i++ {
-		// 	ext_id, _ := adts.reader.ReadBitsAsUInt8(2)
-		// 	e.Bs_extension_id = append(e.Bs_extension_id, ext_id)
-		// 	if e.Bs_extension_id[i] == EXTENSION_ID_PS {
-		// 		num_bits_left -= 2
-
-		// 		bits_read, ext, err := adts.sbr_extension(e.Bs_extension_id[i], num_bits_left)
-		// 		if err != nil {
-		// 			return e, err
-		// 		}
-		// 		e.Sbr_extension = append(e.Sbr_extension, ext)
-
-		// 		num_bits_left -= bits_read
-		// 		if num_bits_left < 0 {
-		// 			return e, fmt.Errorf("Error: SBR parsing overran available bits")
-		// 		}
-		// 	}
-		// }
-
-		// e.Bs_fill_bits, _ = adts.reader.ReadBitsToByteArray(num_bits_left)
+		// Extentions are currently unsupported
 		adts.reader.SkipBits(num_bits_left)
 	}
 	return e, nil

--- a/aacparser.go
+++ b/aacparser.go
@@ -2033,7 +2033,7 @@ func (adts *ADTS) sbr_single_channel_element(ext_data *sbr_extension_data, bs_am
 
 		num_bits_left := cnt * 8
 		if num_bits_left > MaxBitsLeft {
-			return e, fmt.Errorf("Too many bits left, checl bitstream continuity")
+			return e, fmt.Errorf("Too many bits left, check bitstream continuity")
 		}
 
 		e.Bs_extension_id = make([]uint8, 0)
@@ -2208,7 +2208,7 @@ func (adts *ADTS) sbr_channel_pair_base_element(bs_amp_res bool, ext_data *sbr_e
 		// TODO: could we be a bit more graceful about this block?
 		num_bits_left := cnt * 8
 		if num_bits_left > MaxBitsLeft {
-			return e, fmt.Errorf("Too many bits left, checl bitstream continuity")
+			return e, fmt.Errorf("Too many bits left, check bitstream continuity")
 		}
 
 		e.Bs_extension_id = make([]uint8, 0)

--- a/aacsbrtables.go
+++ b/aacsbrtables.go
@@ -249,14 +249,16 @@ func freq_derived(data *sbr_extension_data, bs_xover_band uint8, k2 uint8) error
 	data.n[0] = data.N_low
 	data.n[1] = data.N_high
 
+	index := data.N_high + bs_xover_band + 1
+
 	// check for overflow or upper bounds
-	if data.N_high+bs_xover_band+1 < bs_xover_band || len(data.f_master) < int(data.N_high+bs_xover_band+1) {
-		return fmt.Errorf("f_tablehigh invalid index, likely malformed")
+	if index < bs_xover_band || len(data.f_master) < int(index) {
+		return fmt.Errorf("f_tablehigh invalid index: index (%d) must be between bs_xover_band (%d) and length of f_master (%d)", index, bs_xover_band, len(data.f_master))
 	}
-	data.f_tablehigh = data.f_master[bs_xover_band : data.N_high+bs_xover_band+1]
-	// index out of range [255] with len 0
+	data.f_tablehigh = data.f_master[bs_xover_band:index]
+	// check f_tablehigh bounds
 	if len(data.f_tablehigh) < int(data.N_high) {
-		return fmt.Errorf("f_tablehigh invalid index, likely malformed")
+		return fmt.Errorf("N_high index (%d) too high for length of f_tablehigh (%d)", data.N_high, len(data.f_tablehigh))
 	}
 	data.M = uint8(data.f_tablehigh[data.N_high] - data.f_tablehigh[0])
 	data.k_x = data.f_tablehigh[0]

--- a/aacsbrtables.go
+++ b/aacsbrtables.go
@@ -85,7 +85,9 @@ func derive_sbr_tables(data *sbr_extension_data, sfi uint8, bs_start_freq uint8,
 	} else {
 		freq_master(data, data.k0, data.k2, bs_freq_scale, bs_alter_scale)
 	}
-	freq_derived(data, bs_xover_band, data.k2)
+	if err := freq_derived(data, bs_xover_band, data.k2); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -239,7 +241,7 @@ func freq_master(data *sbr_extension_data, k0 uint8, k2 uint8, bs_freq_scale uin
 	data.f_master = append(data.f_master, vk1...)
 }
 
-func freq_derived(data *sbr_extension_data, bs_xover_band uint8, k2 uint8) {
+func freq_derived(data *sbr_extension_data, bs_xover_band uint8, k2 uint8) error {
 	data.N_high = data.N_master - bs_xover_band
 	data.N_low = (data.N_high >> 1) + (data.N_high - (data.N_high>>1)<<1)
 
@@ -247,7 +249,15 @@ func freq_derived(data *sbr_extension_data, bs_xover_band uint8, k2 uint8) {
 	data.n[0] = data.N_low
 	data.n[1] = data.N_high
 
+	// check for overflow or upper bounds
+	if data.N_high+bs_xover_band+1 < bs_xover_band || len(data.f_master) < int(data.N_high+bs_xover_band+1) {
+		return fmt.Errorf("f_tablehigh invalid index, likely malformed")
+	}
 	data.f_tablehigh = data.f_master[bs_xover_band : data.N_high+bs_xover_band+1]
+	// index out of range [255] with len 0
+	if len(data.f_tablehigh) < int(data.N_high) {
+		return fmt.Errorf("f_tablehigh invalid index, likely malformed")
+	}
 	data.M = uint8(data.f_tablehigh[data.N_high] - data.f_tablehigh[0])
 	data.k_x = data.f_tablehigh[0]
 
@@ -274,6 +284,8 @@ func freq_derived(data *sbr_extension_data, bs_xover_band uint8, k2 uint8) {
 		}
 		data.f_tablenoise[k] = data.f_tablelow[i]
 	}
+
+	return nil
 }
 
 // TODO: Implement freq_limiter table


### PR DESCRIPTION
Since we don't support extensions right now I would argue we should just omit them rather than approaching it with no intent to actually parse and use it. I'm running into situations where the parser will get tripped up in the bitstream and try to allocate gigs of memory. 

Additionally:
- excluded_channels.Additional_excluded_chns was never allocated resulting in a panic
- Add checks to not allocate the world elsewhere as well