### PR TITLE
Fixing parse for SBR extension channel pair element

### DIFF
--- a/aacparser.go
+++ b/aacparser.go
@@ -422,7 +422,7 @@ type sbr_channel_pair_enhance_element struct {
 }
 
 type sbr_grid struct {
-	Bs_frame_class uint8
+	Bs_frame_class [2]uint8
 
 	Tmp         uint8 // Yes, this is an official bit field in the spec...
 	Bs_freq_res [][]uint8
@@ -2262,8 +2262,8 @@ func (adts *ADTS) sbr_channel_pair_enhance_element(bs_amp_res bool) *sbr_channel
 // Table 4.69 – Syntax of sbr_grid()
 ////////////////////////////////////////////////////////////////////////////////
 func (adts *ADTS) sbr_grid(ch uint, data *sbr_grid, header *sbr_header) error {
-	data.Bs_frame_class, _ = adts.reader.ReadBitsAsUInt8(2)
-	switch data.Bs_frame_class {
+	data.Bs_frame_class[ch], _ = adts.reader.ReadBitsAsUInt8(2)
+	switch data.Bs_frame_class[ch] {
 	case FIXFIX:
 		data.Tmp, _ = adts.reader.ReadBitsAsUInt8(2)
 		data.bs_num_env = append(data.bs_num_env, 1<<data.Tmp)
@@ -2408,7 +2408,7 @@ func (adts *ADTS) sbr_envelope(
 	var f_huff [][]int8
 
 	amp_res := bs_amp_res
-	if grid.bs_num_env[ch] == 1 && grid.Bs_frame_class == FIXFIX {
+	if grid.bs_num_env[ch] == 1 && grid.Bs_frame_class[ch] == FIXFIX {
 		amp_res = false
 	}
 

--- a/aacparser_test.go
+++ b/aacparser_test.go
@@ -228,6 +228,24 @@ func TestSbrExists(t *testing.T) {
 	}
 }
 
+func TestSbrChannelPairElementParse(t *testing.T) {
+	buf, err := base64.StdEncoding.DecodeString(
+		"//FYgD+BnCEbQ9uJooYaHEyKrWaAZUmYoqZdSkJUqh/ZoD0ZT3iVbMTgNe8FuI6HSt1vZoAcY13PUkjIqz2PXN82feqhznnAoQwAnAYzxDC3VbYX7x1oyZMJJDh0nozSuFKVaJUjeJVUi01puKLL3LdgXpQyDr0hZa9PAvAtQvxBLVNTXGa6FRWh2VU1r+fA3WhRZP1ChIYijIlCvUJgErbYRTWCgmIghE9cuudbSXxrNF5VNQ3LbkkuRBA6hl73rHJa8C2vUAhslyiC8nspS800OvMc3YzrTHnNlrcYMCXC/Bwha6I5KDVXi3O5UQaDWyinMlymVxOeNUp3FbdbWC4+KfCKGNPbI0aNSYxoo1b0xpUqoWRTZ1p8UU5gqnHFRzrmnThZGNyD8MZa7Y/NYOdthRkyZyD+S1nc0HDm2WoPc7O23AWWNkcLa/kTFekvbxFTk6DcJjxM3IQeqK2gKo5NynkRqIKyFspol79egkg3O8DIf68aWV/C4qjg0r5ODFsMHZQfTQI7ukK2Fh33vrHrN2OlhayZAQJp0gE2DCaInTHGgCpmmag8WmNqWBDZmRmZgmxZobHrmRPKCRtiEkAX8pJblEvdB61vNxNE3WJlvefJV7Y+FLJAXUA3gG8N37ATwNsYoCIAAAAAE/fwe/879/u5fmSNCBAA8w==")
+	adts, err := ParseADTS(buf)
+	if err != nil {
+		t.Errorf("err (%s) must be nil", err.Error())
+	}
+	if adts.Fill_elements == nil {
+		t.Errorf("Fill_elements cannot be nil")
+	}
+	if adts.Fill_elements[0].Extension_payload == nil {
+		t.Errorf("Extension_payload cannot be nil")
+	}
+	if int(adts.Fill_elements[0].Extension_payload.Extension_type) != EXT_SBR_DATA {
+		t.Errorf("Extension_type (%d) must be of type EXT_SBR_DATA (%d)", adts.Fill_elements[0].Extension_payload.Extension_type, EXT_SBR_DATA)
+	}
+}
+
 // AAC Audio frame with a full, parsable SBR
 func TestSbrParse(t *testing.T) {
 	buf, err := base64.StdEncoding.DecodeString(


### PR DESCRIPTION
When parsing an SBR extension containing an `sbr_channel_pair_element`, the value of `bs_frame_class` (from `sbr_grid`) is overwritten, rather than stored per channel.  The value of `bs_frame_class` is later needed to select the HCB used in `sbr_envelope`, and may cause a parse error when set incorrectly.

The test added in this request, `TestSbrChannelPairElementParse`, run against the current head (7cb3b3c) demonstrates the issue:

```text
$ go test . -run ^TestSbrChannelPairElementParse  -v
=== RUN   TestSbrChannelPairElementParse
    aacparser_test.go:236: err (sbr extension payload malformed) must be nil
--- FAIL: TestSbrChannelPairElementParse (0.00s)
FAIL
FAIL  github.com/Comcast/gaad 0.008s
FAIL
```

Both [libfaad](https://github.com/knik0/faad2/blob/a65ecabd13a6b991781d75856e1b6870ce00fc70/libfaad/sbr_syntax.c#L668-L669) and [FFmpeg](https://github.com/FFmpeg/FFmpeg/blob/e3580f60775c897c3b13b178c57ab191ecc4a031/libavcodec/aacsbr_template.c#L1021-L1022) set `bs_frame_class` per channel:

Storing `bs_frame_class` per channel, as it is in this request, passes the aforementioned test and all other package tests.