### PR TITLE
Add logic to double SamplingFrequency for HE-AAC streams

### DIFF
--- a/aacparser.go
+++ b/aacparser.go
@@ -1906,6 +1906,8 @@ func (adts *ADTS) sbr_extension_data(cnt int, id_aac uint8, crc_flag bool) (int,
 			sfi = 8
 		}
 
+		adts.SamplingFrequency = SamplingFrequency[sfi]
+
 		err = derive_sbr_tables(data, uint8(sfi), data.Sbr_header.Bs_start_freq, data.Sbr_header.Bs_stop_freq,
 			data.Sbr_header.Bs_freq_scale, data.Sbr_header.Bs_alter_scale, data.Sbr_header.Bs_xover_band)
 		if err != nil {


### PR DESCRIPTION
For HE-AAC streams with implicitly-signaled SBR, the output sample rate is twice the parsed sampling frequency, per ISO/IEC 14496-3:2019 1.6.5.2 and 1.6.5.3.

This logic was partially implemented in `sbr_extension_data()`, which was adjusting the sampling frequency index (SFI). However, the new SFI was not being used to adjust the output sample rate, like it is now.

I have also added a new unit test `TestCompleteHeAacAdts` and clarified some of the other test scenarios. 